### PR TITLE
Refactoring: Use protected classes, isComponent

### DIFF
--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -1,14 +1,16 @@
 import { TYPES, RESIZER_NONE, MAX_COLUMNS } from '../consts'
+import { elHasClass } from './utils'
+
+const type = TYPES.column
 
 export default (domComponents, { editor, ...config }) => {
-  domComponents.addType(TYPES.column, {
+  domComponents.addType(type, {
     extend: 'cell',
     model: {
       defaults: {
         tagName: 'td',
         name: 'Column',
-        styles: `
-          [data-gjs-type="${TYPES.column}"]{}          
+        styles: `        
           [data-gs-columns="1"] {width: 8.3333%;}          
           [data-gs-columns="2"] {width: 16.6666%;}          
           [data-gs-columns="3"] {width: 25%;}          
@@ -72,7 +74,9 @@ export default (domComponents, { editor, ...config }) => {
         ...config.columnProps,
       },
 
-      init() {},
+      init() {
+        this.get('classes').pluck('name').indexOf(type) < 0 && this.addClass(type);
+      },
 
       setColumns(value) {
         if (!value) return
@@ -85,7 +89,7 @@ export default (domComponents, { editor, ...config }) => {
         const attributes = this.getAttributes()
         const value = attributes['data-gs-columns']
         let result = value
-        if (typeof trait === 'string' && !isNaN(parseInt(value))) result = parseInt(value)
+        if (typeof value === 'string' && !isNaN(parseInt(value))) result = parseInt(value)
         return result
       },
 
@@ -132,7 +136,7 @@ export default (domComponents, { editor, ...config }) => {
 
     isComponent(el) {
       // return el.dataset && el.dataset.gjsType === TYPES.column;
-      return false
+      if (elHasClass(el, type)) return { type };
     },
   })
 }

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,7 +1,9 @@
 import { ACTIONS, TYPES, MAX_COLUMNS } from '../consts'
+import { elHasClass } from './utils'
+
 const type = TYPES.row
 
-export default (domComponents, { editor, ...config }) => {
+export default (domComponents, { editor }) => {
   domComponents.addType(type, {
     extend: 'row',
     model: {
@@ -14,12 +16,13 @@ export default (domComponents, { editor, ...config }) => {
         attributes: {
           'data-dm-category': 'layout',
         },
-        styles: `
-        [data-gjs-type="${type}"] {
-          display:table-row;
-        } `,
       },
       init() {
+        const css = editor.Css;
+        this.get('classes').pluck('name').indexOf(type) < 0 && this.addClass(type);
+        css.getRule(`.${type}`) || css.setRule(`.${type}`, {
+          display: 'table-row',
+        });
         editor.on('component:add', (component) => {
           const parent = component.parent()
           if (parent && parent.components().models.length > MAX_COLUMNS) {
@@ -50,7 +53,7 @@ export default (domComponents, { editor, ...config }) => {
     },
     isComponent(el) {
       // return el.dataset && el.dataset.gjsType === TYPES.section;
-      return false
+      if (elHasClass(el, type)) return { type };
     },
   })
 }

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,4 +1,5 @@
-import { TYPES } from '../consts'
+import { TYPES, RESIZER_NONE } from '../consts'
+import { elHasClass } from './utils'
 
 const type = TYPES.table
 
@@ -12,20 +13,27 @@ export default (domComponents, { editor, ...config }) => {
         badgable: true,
         selectable: true,
         hoverable: true,
-        draggable: `.wrapper, [data-gjs-type=${TYPES.column}]`, // IT CAN BE DRAGGED INTO these components
+        draggable: `[data-gjs-type=wrapper], [data-gjs-type=${TYPES.column}]`, // IT CAN BE DRAGGED INTO these components
         droppable: false, // these components CAN BE DROPPED INTO IT
-        styles: `
-          [data-gjs-type="${type}"] {
-            display:table;
-            width:100%;
-          }`,
+        resizable: {
+          ...RESIZER_NONE,
+          bc: true,
+        },
         ...config.rowProps,
       },
-      init() {},
+      init() {
+        const css = editor.Css;
+        this.get('classes').pluck('name').indexOf(type) < 0 && this.addClass(type);
+        css.getRule(`.${type}`) || css.setRule(`.${type}`, {
+          display: 'table',
+          width: '100%',
+          height: '250px',
+        });
+      },
     },
     isComponent(el) {
       // return el.dataset && el.dataset.gjsType === TYPES.section;
-      return false
+      if (elHasClass(el, type)) return { type };
     },
   })
 }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,9 +2,11 @@ import Column from './Column'
 import Row from './Row'
 import Table from './Table'
 import defaults from './options'
+import { TYPES } from '../consts'
 
 export default (editor, config = {}) => {
   const dc = editor.DomComponents
+  const { table, row, column } = TYPES;
   const opts = {
     ...defaults,
     ...config,
@@ -12,5 +14,13 @@ export default (editor, config = {}) => {
     editor,
   }
 
-  ;[Table, Row, Column].forEach((c) => c(dc, opts))
+  const privateCls = [`.${table}`, `.${row}`, `.${column}`];
+  editor.on(
+    'selector:add',
+    selector =>
+      privateCls.indexOf(selector.getFullName()) >= 0 &&
+      selector.set('private', 1)
+  );
+
+  [Table, Row, Column].forEach((c) => c(dc, opts))
 }

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -1,0 +1,7 @@
+const elHasClass = (el, toFind) => {
+    let cls = el.className;
+    cls = cls && cls.toString();
+    if (cls && cls.split(" ").indexOf(toFind) >= 0) return 1;
+};
+
+export { elHasClass };


### PR DESCRIPTION
Use protected classes instead of the `data-gjs-type` attribute, isComponent functions can detect components using these protected classes